### PR TITLE
Fix README code error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tmdbClient.SetClientConfig(http.Client{Timeout: time.Second * 5})
 
 // OPTIONAL (Recommended): Enabling auto retry functionality.
 // This option will retry if the previous request fail.
-tmdbClient.SetAutoRetry()
+tmdbClient.SetClientAutoRetry()
 
 if err != nil {
     fmt.Println(err)


### PR DESCRIPTION
Example function name was incorrect.