### PR TITLE
Fix JSON meta data of production country ISO code

### DIFF
--- a/movies.go
+++ b/movies.go
@@ -35,7 +35,7 @@ type MovieDetails struct {
 		OriginCountry string `json:"origin_country"`
 	} `json:"production_companies"`
 	ProductionCountries []struct {
-		Iso3166_1 string `json:"iso_31661_1"`
+		Iso3166_1 string `json:"iso_3166_1"`
 		Name      string `json:"name"`
 	} `json:"production_countries"`
 	ReleaseDate     string `json:"release_date"`


### PR DESCRIPTION
# Description

Fixes the typo in json metada of Iso3166_1 for ProductionCountries in MovieDetails

Fixes #14 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Yes

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
