### PR TITLE
Watch/providers for movies and TV shows

### DIFF
--- a/movies.go
+++ b/movies.go
@@ -66,6 +66,7 @@ type MovieDetails struct {
 	*MovieSimilarAppend
 	*MovieReviewsAppend
 	*MovieListsAppend
+	*MovieWatchProvidersAppend
 }
 
 // MovieAlternativeTitlesAppend type is a struct for alternative
@@ -141,6 +142,12 @@ type MovieKeywordsAppend struct {
 	Keywords struct {
 		*MovieKeywords
 	} `json:"keywords,omitempty"`
+}
+
+// MovieWatchProvidersAppend type is a struct for
+// watch/providers in append to response.
+type MovieWatchProvidersAppend struct {
+	WatchProviders *MovieWatchProviders `json:"watch/providers,omitempty"`
 }
 
 // GetMovieDetails get the primary information about a movie.
@@ -513,6 +520,55 @@ func (c *Client) GetMovieVideos(
 		return nil, err
 	}
 	return &movieVideos, nil
+}
+
+// MovieWatchProviders type is a struct for watch/providers JSON response.
+type MovieWatchProviders struct {
+	ID      int64 `json:"id,omitempty"`
+	Results map[string]struct {
+		Link     string `json:"link"`
+		Flatrate []struct {
+			DisplayPriority int64  `json:"display_priority"`
+			LogoPath        string `json:"logo_path"`
+			ProviderID      int64  `json:"provider_id"`
+			ProviderName    string `json:"provider_name"`
+		} `json:"flatrate,omitempty"`
+		Rent []struct {
+			DisplayPriority int64  `json:"display_priority"`
+			LogoPath        string `json:"logo_path"`
+			ProviderID      int64  `json:"provider_id"`
+			ProviderName    string `json:"provider_name"`
+		} `json:"rent,omitempty"`
+		Buy []struct {
+			DisplayPriority int64  `json:"display_priority"`
+			LogoPath        string `json:"logo_path"`
+			ProviderID      int64  `json:"provider_id"`
+			ProviderName    string `json:"provider_name"`
+		} `json:"buy,omitempty"`
+	} `json:"results"`
+}
+
+// GetMovieWatchProviders get a list of the availabilities per country by provider for a movie.
+//
+// https://developers.themoviedb.org/3/movies/get-movie-watch-providers
+func (c *Client) GetMovieWatchProviders(
+	id int,
+	urlOptions map[string]string,
+) (*MovieWatchProviders, error) {
+	options := c.fmtOptions(urlOptions)
+	tmdbURL := fmt.Sprintf(
+		"%s%s%d/watch/providers?api_key=%s%s",
+		baseURL,
+		movieURL,
+		id,
+		c.apiKey,
+		options,
+	)
+	movieWatchProviders := MovieWatchProviders{}
+	if err := c.get(tmdbURL, &movieWatchProviders); err != nil {
+		return nil, err
+	}
+	return &movieWatchProviders, nil
 }
 
 // MovieTranslations type is a struct for translations JSON response.

--- a/movies_test.go
+++ b/movies_test.go
@@ -217,6 +217,17 @@ func (suite *TMBDTestSuite) TestGetMovieRecommendationsWithOptions() {
 	suite.Equal(int64(1), jackreacher.Page)
 }
 
+func (suite *TMBDTestSuite) TestGetMovieWatchProviders() {
+	bumblebee, err := suite.client.GetMovieWatchProviders(bumblebeeID, nil)
+	suite.Nil(err)
+	suite.Equal("https://www.themoviedb.org/movie/424783-bumblebee/watch?locale=AR", bumblebee.Results["AR"].Link)
+}
+
+func (suite *TMBDTestSuite) TestGetMovieWatchProvidersFail() {
+	_, err := suite.client.GetMovieWatchProviders(0, nil)
+	suite.Equal("code: 34 | success: false | message: The resource you requested could not be found.", err.Error())
+}
+
 func (suite *TMBDTestSuite) TestGetMovieSimilar() {
 	bumblebee, err := suite.client.GetMovieSimilar(bumblebeeID, nil)
 	suite.Nil(err)

--- a/tv.go
+++ b/tv.go
@@ -102,6 +102,7 @@ type TVDetails struct {
 	*TVSimilarAppend
 	*TVTranslationsAppend
 	*TVVideosAppend
+	*TVWatchProvidersAppend
 }
 
 // TVAlternativeTitlesAppend type is a struct
@@ -188,6 +189,12 @@ type TVVideosAppend struct {
 	Videos struct {
 		*TVVideos
 	} `json:"videos,omitempty"`
+}
+
+// TVWatchProvidersAppend type is a struct for
+// watch/providers in append to response.
+type TVWatchProvidersAppend struct {
+	WatchProviders *TVWatchProviders `json:"watch/providers,omitempty"`
 }
 
 // GetTVDetails get the primary TV show details by id.
@@ -721,6 +728,55 @@ func (c *Client) GetTVSimilar(
 		return nil, err
 	}
 	return &tVSimilar, nil
+}
+
+// TVWatchProviders type is a struct for watch/providers JSON response.
+type TVWatchProviders struct {
+	ID      int64 `json:"id,omitempty"`
+	Results map[string]struct {
+		Link     string `json:"link"`
+		Flatrate []struct {
+			DisplayPriority int64  `json:"display_priority"`
+			LogoPath        string `json:"logo_path"`
+			ProviderID      int64  `json:"provider_id"`
+			ProviderName    string `json:"provider_name"`
+		} `json:"flatrate,omitempty"`
+		Rent []struct {
+			DisplayPriority int64  `json:"display_priority"`
+			LogoPath        string `json:"logo_path"`
+			ProviderID      int64  `json:"provider_id"`
+			ProviderName    string `json:"provider_name"`
+		} `json:"rent,omitempty"`
+		Buy []struct {
+			DisplayPriority int64  `json:"display_priority"`
+			LogoPath        string `json:"logo_path"`
+			ProviderID      int64  `json:"provider_id"`
+			ProviderName    string `json:"provider_name"`
+		} `json:"buy,omitempty"`
+	} `json:"results"`
+}
+
+// GetTVWatchProviders get a list of the availabilities per country by provider for a TV show.
+//
+// https://developers.themoviedb.org/3/tv/get-tv-watch-providers
+func (c *Client) GetTVWatchProviders(
+	id int,
+	urlOptions map[string]string,
+) (*TVWatchProviders, error) {
+	options := c.fmtOptions(urlOptions)
+	tmdbURL := fmt.Sprintf(
+		"%s%s%d/watch/providers?api_key=%s%s",
+		baseURL,
+		tvURL,
+		id,
+		c.apiKey,
+		options,
+	)
+	tvWatchProviders := TVWatchProviders{}
+	if err := c.get(tmdbURL, &tvWatchProviders); err != nil {
+		return nil, err
+	}
+	return &tvWatchProviders, nil
 }
 
 // TVTranslations type is a struct for translations JSON response.

--- a/tv_test.go
+++ b/tv_test.go
@@ -236,6 +236,17 @@ func (suite *TMBDTestSuite) TestGetTVReviewsWithOptions() {
 	suite.Equal(int64(1), flash.Page)
 }
 
+func (suite *TMBDTestSuite) TestGetTVWatchProviders() {
+	bumblebee, err := suite.client.GetTVWatchProviders(flashID, nil)
+	suite.Nil(err)
+	suite.Equal("https://www.themoviedb.org/tv/60735-the-flash/watch?locale=AR", bumblebee.Results["AR"].Link)
+}
+
+func (suite *TMBDTestSuite) TestGetTVWatchProvidersFail() {
+	_, err := suite.client.GetTVWatchProviders(0, nil)
+	suite.Equal("code: 34 | success: false | message: The resource you requested could not be found.", err.Error())
+}
+
 func (suite *TMBDTestSuite) TestGetTVSimilar() {
 	flashID, err := suite.client.GetTVSimilar(flashID, nil)
 	suite.Nil(err)


### PR DESCRIPTION
# Description

- Separate methods for getting watch/providers (a list of the availabilities per country by provider) for movies and TV shows
- Ability to append watch/providers property for MovieDetails and TVDetails objects

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

You can call `GetMovieWatchProviders`, `GetTVWatchProviders`, `GetMovieDetails` (with `watch/providers` value in the `append_to_response` option), `GetTVDetails` (with `watch/providers` value in the `append_to_response` option) methods to verify my changes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
