### PR TITLE
Added missing fields to TVDetails and TVCredits

### DIFF
--- a/tv.go
+++ b/tv.go
@@ -75,6 +75,10 @@ type TVDetails struct {
 		LogoPath      string `json:"logo_path"`
 		OriginCountry string `json:"origin_country"`
 	} `json:"production_companies"`
+	ProductionCountries []struct {
+		Iso3166_1 string `json:"iso_3166_1"`
+		Name      string `json:"name"`
+	} `json:"production_countries"`
 	Seasons []struct {
 		AirDate      string `json:"air_date"`
 		EpisodeCount int    `json:"episode_count"`
@@ -441,22 +445,28 @@ func (c *Client) GetTVContentRatings(
 type TVCredits struct {
 	ID   int64 `json:"id,omitempty"`
 	Cast []struct {
-		Character   string `json:"character"`
-		CreditID    string `json:"credit_id"`
-		Gender      int    `json:"gender"`
-		ID          int64  `json:"id"`
-		Name        string `json:"name"`
-		Order       int    `json:"order"`
-		ProfilePath string `json:"profile_path"`
+		Character          string  `json:"character"`
+		CreditID           string  `json:"credit_id"`
+		Gender             int     `json:"gender"`
+		ID                 int64   `json:"id"`
+		KnownForDepartment string  `json:"known_for_department"`
+		Name               string  `json:"name"`
+		Order              int     `json:"order"`
+		OriginalName       string  `json:"original_name"`
+		Popularity         float32 `json:"popularity"`
+		ProfilePath        string  `json:"profile_path"`
 	} `json:"cast"`
 	Crew []struct {
-		CreditID    string `json:"credit_id"`
-		Department  string `json:"department"`
-		Gender      int    `json:"gender"`
-		ID          int64  `json:"id"`
-		Job         string `json:"job"`
-		Name        string `json:"name"`
-		ProfilePath string `json:"profile_path"`
+		CreditID           string  `json:"credit_id"`
+		Department         string  `json:"department"`
+		Gender             int     `json:"gender"`
+		ID                 int64   `json:"id"`
+		Job                string  `json:"job"`
+		KnownForDepartment string  `json:"known_for_department"`
+		Name               string  `json:"name"`
+		OriginalName       string  `json:"original_name"`
+		Popularity         float32 `json:"popularity"`
+		ProfilePath        string  `json:"profile_path"`
 	} `json:"crew"`
 }
 


### PR DESCRIPTION
# Description

Added the following field to `TVDetails`:
```go
	ProductionCountries []struct {
		Iso3166_1 string `json:"iso_3166_1"`
		Name      string `json:"name"`
	} `json:"production_countries"`
```

Added the following fields to `TVCredits` cast and crew:
```go
KnownForDepartment   string  `json:"known_for_department"`
OriginalName         string  `json:"original_name"`
Popularity           float32 `json:"popularity"`
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have been using this modification locally for a project that needed these fields

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
