### PR TITLE
Introduced a method, SetAlternateBaseURL(), enabling the selection of…

### DIFF
--- a/tmdb.go
+++ b/tmdb.go
@@ -21,7 +21,8 @@ var json = jsoniter.ConfigFastest
 
 // TMDb constants
 const (
-	baseURL           = "https://api.themoviedb.org/3"
+	defaultBaseURL    = "https://api.themoviedb.org/3"
+	alternateBaseURL  = "https://api.tmdb.org/3"
 	permissionURL     = "https://www.themoviedb.org/authenticate/"
 	authenticationURL = "/authentication/"
 	movieURL          = "/movie/"
@@ -43,6 +44,8 @@ const (
 	accountURL        = "/account/"
 	watchProvidersURL = "/watch/providers/"
 )
+
+var baseURL = defaultBaseURL
 
 // Client type is a struct to instantiate this pkg.
 type Client struct {
@@ -216,6 +219,11 @@ func (c *Client) fmtOptions(
 		}
 	}
 	return options
+}
+
+// SetAlternateBaseURL sets an alternate base url.
+func (c *Client) SetAlternateBaseURL() {
+	baseURL = alternateBaseURL
 }
 
 // Error type represents an error returned by the TMDB API.


### PR DESCRIPTION
Introduced a method, SetAlternateBaseURL(), enabling the selection of alternative API base URLs to accommodate varying network conditions across countries.

# Description

In my country, accessing api.themoviedb.org is restricted in many regions, while api.tmdb.org remains accessible. SetAlternateBaseURL() can be called after Init() to toggle the requested API URL.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

All test cases from the original project have passed. Utilizing the new SwitchBaseURL(TMDB) function yields accurate results when querying data as well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
