### PR TITLE
add runtime for tv episodes

### DIFF
--- a/tv_episodes.go
+++ b/tv_episodes.go
@@ -32,6 +32,7 @@ type TVEpisodeDetails struct {
 	Overview       string  `json:"overview"`
 	ID             int64   `json:"id"`
 	ProductionCode string  `json:"production_code"`
+	Runtime        int     `json:"runtime"`
 	SeasonNumber   int     `json:"season_number"`
 	StillPath      string  `json:"still_path"`
 	VoteAverage    float32 `json:"vote_average"`


### PR DESCRIPTION
# Description

This adds the `TVEpisode`'s `Runtime` from the API response.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
