### PR TITLE
Add person translations name and primary

### DIFF
--- a/people.go
+++ b/people.go
@@ -488,6 +488,8 @@ type PersonTranslations struct {
 		Name      string `json:"name"`
 		Data      struct {
 			Biography string `json:"biography"`
+			Name      string `json:"name"`
+			Primary   bool   `json:"primary"`
 		} `json:"data"`
 		EnglishName string `json:"english_name"`
 	} `json:"translations"`

--- a/people_test.go
+++ b/people_test.go
@@ -24,6 +24,17 @@ func (suite *TMBDTestSuite) TestGetPersonDetailsWithOptions() {
 	suite.Equal("Jason Momoa", jasonMomoa.Name)
 }
 
+func (suite *TMBDTestSuite) TestGetPersonDetailsWithAppend() {
+	options := make(map[string]string)
+	options["append_to_response"] = "translations"
+	jasonMomoa, err := suite.client.GetPersonDetails(jasonMomoaID, options)
+	suite.Nil(err)
+	suite.NotNil(jasonMomoa.PersonTranslationsAppend)
+	suite.NotNil(jasonMomoa.Translations)
+	suite.NotEmpty(jasonMomoa.Translations.Translations)
+	suite.Equal("Jason Momoa", jasonMomoa.Translations.Translations[0].Data.Name)
+}
+
 func (suite *TMBDTestSuite) TestGetPersonChanges() {
 	jasonMomoa, err := suite.client.GetPersonChanges(jasonMomoaID, nil)
 	suite.Nil(err)
@@ -174,6 +185,8 @@ func (suite *TMBDTestSuite) TestGetPersonTranslationsWithOptions() {
 	tomCruise, err := suite.client.GetPersonTranslations(tomCruiseID, options)
 	suite.Nil(err)
 	suite.NotNil(tomCruise.ID)
+	suite.NotEmpty(tomCruise.Translations)
+	suite.NotEmpty(tomCruise.Translations[0].Data.Name)
 }
 
 func (suite *TMBDTestSuite) TestGetPersonLatest() {


### PR DESCRIPTION
# Description

Add 2 missing fields for person translations: `name` and `primary`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added tests cases for it and run them.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
