### PR TITLE
Feat/ctx improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This product uses the TMDb API but is not endorsed or certified by TMDb.
 
 ## Requirements
 
-- Go 1.13.x or higher. We aim to support the latest supported versions of go.
+- Go 1.18.x or higher. We aim to support the latest supported versions of go.
 
 ## Installation
 
@@ -36,7 +36,7 @@ if err != nil {
     fmt.Println(err)
 }
 
-// OPTIONAL (Recommended): Enabling auto retry functionality.
+// OPTIONAL: Enabling auto retry functionality.
 // This option will retry if the previous request fail (429 TOO MANY REQUESTS).
 tmdbClient.SetClientAutoRetry()
 

--- a/tmdb_test.go
+++ b/tmdb_test.go
@@ -1,7 +1,10 @@
 package tmdb
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,11 +30,56 @@ func TestSuite(t *testing.T) {
 
 func (suite *TMBDTestSuite) TestGetFail() {
 	err := suite.client.get("http://www.testfakewebsite.org", nil)
+	suite.Error(err)
 	suite.Contains(err.Error(), "no such host")
 	err = suite.client.get("https://api.themoviedb.org/3/movie/7578000?language=en-US", nil)
-	suite.Contains("code: 7 | success: false | message: Invalid API key: You must be granted a valid key.", err.Error())
+	suite.Error(err)
+	suite.Contains(err.Error(), "code: 7 | success: false | message: Invalid API key: You must be granted a valid key.")
 	err = suite.client.get("", nil)
+	suite.Error(err)
 	suite.Equal("url field is empty", err.Error())
+	var invalidTarget int
+	err = suite.client.get("https://www.google.com.br", &invalidTarget)
+	if err != nil {
+		suite.Contains(err.Error(), "could not decode the data")
+	}
+}
+
+func (suite *TMBDTestSuite) TestGetSpecialCases() {
+	err := suite.client.get("http://[::1]:namedport", nil)
+	suite.Error(err)
+	suite.Contains(err.Error(), "could not fetch the url")
+
+	c := Client{bearerToken: "FAKE_BEARER_TOKEN"}
+	err = c.get("https://api.themoviedb.org/3/movie/7578000?language=en-US", nil)
+	suite.Error(err)
+	suite.True(
+		strings.Contains(err.Error(), "Invalid access token") ||
+			strings.Contains(err.Error(), "Invalid API key"),
+	)
+
+	retryCalled := false
+	tsRetry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		retryCalled = true
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(429)
+		w.Write([]byte(`{"status_code":25,"status_message":"Your request count (#) is over the allowed limit of (40).","success":false}`))
+	}))
+	defer tsRetry.Close()
+	err = suite.client.get(tsRetry.URL, nil)
+	suite.Error(err)
+	suite.True(retryCalled)
+	suite.True(
+		strings.Contains(err.Error(), "over the allowed limit") ||
+			strings.Contains(err.Error(), "context deadline exceeded"),
+	)
+
+	tsNoContent := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer tsNoContent.Close()
+	err = suite.client.get(tsNoContent.URL, nil)
+	suite.Nil(err)
 }
 
 func (suite *TMBDTestSuite) TestRequestFail() {
@@ -41,27 +89,77 @@ func (suite *TMBDTestSuite) TestRequestFail() {
 		"POST",
 		nil,
 	)
+	suite.Error(err)
 	suite.Contains(err.Error(), "no such host")
+
 	err = suite.client.request(
 		"https://api.themoviedb.org/3/authentication/session/new",
 		[]byte{},
 		"POST",
 		nil,
 	)
+	suite.Error(err)
 	suite.Contains(
-		"code: 7 | success: false | message: Invalid API key: You must be granted a valid key.",
 		err.Error(),
-		nil,
+		"code: 7 | success: false | message: Invalid API key: You must be granted a valid key.",
 	)
+
 	err = suite.client.request("", []byte{}, "POST", nil)
+	suite.Error(err)
 	suite.Equal("url field is empty", err.Error())
-	// b := struct {
-	// 	Title string `json:"title"`
-	// }{
-	// 	Title: "Test",
-	// }
-	// err = suite.client.request("https://jsonplaceholder.typicode.com/todos", b, "POST", nil)
-	// suite.Contains(err.Error(), "could not decode the data")
+
+	var invalidTarget int
+	err = suite.client.request("https://api.themoviedb.org/3/movie/7578000?language=en-US", nil, "GET", &invalidTarget)
+	suite.Error(err)
+	suite.True(
+		strings.Contains(err.Error(), "could not decode the data") ||
+			strings.Contains(err.Error(), "couldn't decode error"),
+	)
+}
+
+func (suite *TMBDTestSuite) TestRequestSpecialCases() {
+	err := suite.client.request("http://[::1]:namedport", nil, "GET", nil)
+	suite.Error(err)
+	suite.Contains(err.Error(), "could not fetch the url")
+
+	c := Client{bearerToken: "FAKE_BEARER_TOKEN"}
+	err = c.request("https://api.themoviedb.org/3/movie/7578000?language=en-US", nil, "GET", nil)
+	suite.Error(err)
+	suite.True(
+		strings.Contains(err.Error(), "Invalid") ||
+			strings.Contains(err.Error(), "API key") ||
+			strings.Contains(err.Error(), "access token") ||
+			strings.Contains(strings.ToLower(err.Error()), "decode error") ||
+			strings.Contains(strings.ToLower(err.Error()), "error"),
+	)
+
+	retryCalled := false
+	tsRetry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		retryCalled = true
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(429)
+		w.Write([]byte(`{"status_code":25,"status_message":"Your request count (#) is over the allowed limit of (40).","success":false}`))
+	}))
+	defer tsRetry.Close()
+	c.http.Timeout = time.Second * 10
+	err = c.request(tsRetry.URL, nil, "GET", nil)
+	suite.Error(err)
+	suite.True(retryCalled)
+	suite.True(
+		strings.Contains(err.Error(), "over the allowed limit") ||
+			strings.Contains(err.Error(), "context deadline exceeded"),
+	)
+
+	var invalidTarget int
+	tsDecode := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"foo": "bar"}`))
+	}))
+	defer tsDecode.Close()
+	err = suite.client.request(tsDecode.URL, nil, "GET", &invalidTarget)
+	suite.Error(err)
+	suite.Contains(err.Error(), "could not decode the data")
 }
 
 func (suite *TMBDTestSuite) TestDecodeDataFail() {
@@ -78,15 +176,16 @@ func (suite *TMBDTestSuite) TestDecodeErrorFail() {
 	suite.Contains(err.Error(), "couldn't decode error")
 }
 
-// func (suite *TMBDTestSuite) TestDecodeErrorEmptyBodyFail() {
-// 	r, err := http.Get("https://go.dev/")
-// 	suite.Nil(err)
-// 	r.Write(bytes.NewBuffer([]byte("")))
-// 	err = suite.client.decodeError(r)
-// 	defer r.Body.Close()
-// 	suite.Contains(err.Error(), "empty body")
-// }
-
+func (suite *TMBDTestSuite) TestDecodeErrorEmptyBody() {
+	resp := &http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	err := suite.client.decodeError(resp)
+	suite.Error(err)
+	suite.Contains(err.Error(), "empty body")
+	suite.Contains(err.Error(), "400")
+}
 func (suite *TMBDTestSuite) TestDecodeErrorReadBodyFail() {
 	r, err := http.Get("https://go.dev/")
 	suite.Nil(err)

--- a/tv_episodes.go
+++ b/tv_episodes.go
@@ -254,13 +254,13 @@ func (c *Client) GetTVEpisodeExternalIDs(
 
 // TVEpisodeImage type is a struct for a single image.
 type TVEpisodeImage struct {
-	AspectRatio float32     `json:"aspect_ratio"`
-	FilePath    string      `json:"file_path"`
-	Height      int         `json:"height"`
-	Iso6391     interface{} `json:"iso_639_1"`
-	VoteAverage float32     `json:"vote_average"`
-	VoteCount   int64       `json:"vote_count"`
-	Width       int         `json:"width"`
+	AspectRatio float32 `json:"aspect_ratio"`
+	FilePath    string  `json:"file_path"`
+	Height      int     `json:"height"`
+	Iso6391     any     `json:"iso_639_1"`
+	VoteAverage float32 `json:"vote_average"`
+	VoteCount   int64   `json:"vote_count"`
+	Width       int     `json:"width"`
 }
 
 // TVEpisodeImages type is a struct for images JSON response.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- improvements in the context of the `get` and `request` functions. these functions now use `context.withtimeout` to ensure that http requests have a timeout, preventing them from hanging indefinitely. a default timeout of 10 seconds is applied if `c.http.timeout` is not configured.
 - the `interface{}` type has been replaced with `any` in some parts of the code (functions and structs). this change aims to modernize the code and take advantage of the new keyword introduced in go 1.18, which is an alias for `interface{}`. this improves code readability without altering functionality for go versions >= 1.18. for compatibility with earlier versions, the go code must be compiled with a version prior to 1.18.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Local tests.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
