### PR TITLE
Add vote_average and vote_count to new VoteMetrics struct

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -21,9 +21,8 @@ type CollectionDetails struct {
 		ReleaseDate      string  `json:"release_date"`
 		Title            string  `json:"title"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
-		VoteCount        int64   `json:"vote_count"`
 		Popularity       float32 `json:"popularity"`
+		VoteMetrics
 	} `json:"parts"`
 }
 
@@ -52,9 +51,8 @@ type CollectionImage struct {
 	FilePath    string  `json:"file_path"`
 	Height      int     `json:"height"`
 	Iso639_1    string  `json:"iso_639_1"`
-	VoteAverage float32 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // CollectionImages type is a struct for images JSON response.

--- a/companies.go
+++ b/companies.go
@@ -74,9 +74,8 @@ type CompanyImage struct {
 	Height      int     `json:"height"`
 	ID          string  `json:"id"`
 	FileType    string  `json:"file_type"`
-	VoteAverage float32 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // CompanyImages type is a struct for images JSON response.

--- a/credits.go
+++ b/credits.go
@@ -14,9 +14,7 @@ type CreditsDetails struct {
 		OriginalName     string   `json:"original_name,omitempty"`  // TV
 		OriginalTitle    string   `json:"original_title,omitempty"` // Movie
 		ID               int64    `json:"id"`
-		Name             string   `json:"name,omitempty"` // TV
-		VoteCount        int64    `json:"vote_count"`
-		VoteAverage      float32  `json:"vote_average"`
+		Name             string   `json:"name,omitempty"`           // TV
 		FirstAirDate     string   `json:"first_air_date,omitempty"` // TV
 		PosterPath       string   `json:"poster_path"`
 		ReleaseDate      string   `json:"release_date,omitempty"` // Movie
@@ -38,6 +36,7 @@ type CreditsDetails struct {
 			StillPath     string `json:"still_path"`
 		} `json:"episodes,omitempty"` // TV
 		Seasons []Season `json:"seasons,omitempty"` // TV
+		VoteMetrics
 	} `json:"media"`
 	MediaType string `json:"media_type"`
 	ID        string `json:"id"`
@@ -51,21 +50,20 @@ type CreditsDetails struct {
 			BackdropPath string `json:"backdrop_path"`
 			// GenreIDs         []int64  `json:"genre_ids"` // FIXME: -> []float32
 			// ID               int64    `json:"id"` // FIXME: -> float32
-			OriginalLanguage string  `json:"original_language"`
-			OriginalTitle    string  `json:"original_title,omitempty"`
-			Overview         string  `json:"overview"`
-			PosterPath       string  `json:"poster_path"`
-			ReleaseDate      string  `json:"release_date,omitempty"`
-			Title            string  `json:"title,omitempty"`
-			Video            bool    `json:"video,omitempty"`
-			VoteAverage      float32 `json:"vote_average"`
-			// VoteCount        int64    `json:"vote_count"` // FIXME: -> float32
-			Popularity    float32  `json:"popularity"`
-			MediaType     string   `json:"media_type"`
-			OriginalName  string   `json:"original_name,omitempty"`
-			Name          string   `json:"name,omitempty"`
-			FirstAirDate  string   `json:"first_air_date,omitempty"`
-			OriginCountry []string `json:"origin_country,omitempty"`
+			OriginalLanguage string   `json:"original_language"`
+			OriginalTitle    string   `json:"original_title,omitempty"`
+			Overview         string   `json:"overview"`
+			PosterPath       string   `json:"poster_path"`
+			ReleaseDate      string   `json:"release_date,omitempty"`
+			Title            string   `json:"title,omitempty"`
+			Video            bool     `json:"video,omitempty"`
+			Popularity       float32  `json:"popularity"`
+			MediaType        string   `json:"media_type"`
+			OriginalName     string   `json:"original_name,omitempty"`
+			Name             string   `json:"name,omitempty"`
+			FirstAirDate     string   `json:"first_air_date,omitempty"`
+			OriginCountry    []string `json:"origin_country,omitempty"`
+			VoteMetrics
 		} `json:"known_for"`
 		KnownForDepartment string  `json:"known_for_department"`
 		ProfilePath        string  `json:"profile_path"`

--- a/find.go
+++ b/find.go
@@ -16,9 +16,8 @@ type FindByID struct {
 		ReleaseDate      string  `json:"release_date"`
 		Title            string  `json:"title"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
-		VoteCount        int64   `json:"vote_count"`
 		Popularity       float32 `json:"popularity"`
+		VoteMetrics
 	} `json:"movie_results,omitempty"`
 	PersonResults []struct {
 		Adult    bool   `json:"adult"`
@@ -43,8 +42,7 @@ type FindByID struct {
 			ReleaseDate      string   `json:"release_date,omitempty"` // Movie
 			Title            string   `json:"title,omitempty"`        // Movie
 			Video            bool     `json:"video,omitempty"`        // Movie
-			VoteAverage      float32  `json:"vote_average"`
-			// VoteCount        int64   `json:"vote_count"` // FIXME: -> float32
+			VoteMetrics
 		} `json:"known_for"`
 		KnownForDepartment string  `json:"known_for_department"`
 		ProfilePath        string  `json:"profile_path"`
@@ -54,8 +52,6 @@ type FindByID struct {
 		OriginalName     string   `json:"original_name"`
 		ID               int64    `json:"id"`
 		Name             string   `json:"name"`
-		VoteCount        int64    `json:"vote_count"`
-		VoteAverage      float32  `json:"vote_average"`
 		FirstAirDate     string   `json:"first_air_date"`
 		PosterPath       string   `json:"poster_path"`
 		GenreIDs         []int64  `json:"genre_ids"`
@@ -64,19 +60,19 @@ type FindByID struct {
 		Overview         string   `json:"overview"`
 		OriginCountry    []string `json:"origin_country"`
 		Popularity       float32  `json:"popularity"`
+		VoteMetrics
 	} `json:"tv_results,omitempty"`
 	TvEpisodeResults []struct {
-		AirDate        string  `json:"air_date"`
-		EpisodeNumber  int     `json:"episode_number"`
-		ID             int64   `json:"id"`
-		Name           string  `json:"name"`
-		Overview       string  `json:"overview"`
-		ProductionCode string  `json:"production_code"`
-		SeasonNumber   int     `json:"season_number"`
-		ShowID         int64   `json:"show_id"`
-		StillPath      string  `json:"still_path"`
-		VoteAverage    float32 `json:"vote_average"`
-		VoteCount      int64   `json:"vote_count"`
+		AirDate        string `json:"air_date"`
+		EpisodeNumber  int    `json:"episode_number"`
+		ID             int64  `json:"id"`
+		Name           string `json:"name"`
+		Overview       string `json:"overview"`
+		ProductionCode string `json:"production_code"`
+		SeasonNumber   int    `json:"season_number"`
+		ShowID         int64  `json:"show_id"`
+		StillPath      string `json:"still_path"`
+		VoteMetrics
 	} `json:"tv_episode_results,omitempty"`
 	TvSeasonResults []struct {
 		AirDate      string `json:"air_date"`

--- a/guest_sessions.go
+++ b/guest_sessions.go
@@ -17,9 +17,8 @@ type GuestSessionRatedMovies struct {
 		Popularity       float32 `json:"popularity"`
 		Title            string  `json:"title"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
-		VoteCount        int64   `json:"vote_count"`
 		Rating           float32 `json:"rating"`
+		VoteMetrics
 	} `json:"results"`
 	PaginatedResultsMeta
 }
@@ -61,9 +60,8 @@ type GuestSessionRatedTVShows struct {
 		PosterPath       string   `json:"poster_path"`
 		Popularity       float32  `json:"popularity"`
 		Name             string   `json:"name"`
-		VoteAverage      float32  `json:"vote_average"`
-		VoteCount        int64    `json:"vote_count"`
 		Rating           float32  `json:"rating"`
+		VoteMetrics
 	} `json:"results"`
 	PaginatedResultsMeta
 }
@@ -103,9 +101,8 @@ type GuestSessionRatedTVEpisodes struct {
 		SeasonNumber   int     `json:"season_number"`
 		ShowID         int64   `json:"show_id"`
 		StillPath      string  `json:"still_path"`
-		VoteAverage    float32 `json:"vote_average"`
-		VoteCount      int64   `json:"vote_count"`
 		Rating         float32 `json:"rating"`
+		VoteMetrics
 	} `json:"results"`
 	PaginatedResultsMeta
 }

--- a/keywords.go
+++ b/keywords.go
@@ -43,9 +43,8 @@ type KeywordMovies struct {
 		ReleaseDate      string  `json:"release_date"`
 		Title            string  `json:"title"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
-		VoteCount        int64   `json:"vote_count"`
 		Popularity       float32 `json:"popularity"`
+		VoteMetrics
 	} `json:"results"`
 	PaginatedResultsMeta
 }

--- a/list.go
+++ b/list.go
@@ -29,8 +29,7 @@ type ListDetails struct {
 		ReleaseDate      string   `json:"release_date,omitempty"` // Movie
 		Title            string   `json:"title,omitempty"`        // Movie
 		Video            bool     `json:"video,omitempty"`        // Movie
-		VoteAverage      float32  `json:"vote_average"`
-		VoteCount        int64    `json:"vote_count"`
+		VoteMetrics
 	} `json:"items"`
 	ItemCount  int64  `json:"item_count"`
 	Iso639_1   string `json:"iso_639_1"`

--- a/movies.go
+++ b/movies.go
@@ -33,8 +33,7 @@ type MovieDetails struct {
 	Tagline             string              `json:"tagline"`
 	Title               string              `json:"title"`
 	Video               bool                `json:"video"`
-	VoteAverage         float32             `json:"vote_average"`
-	VoteCount           int64               `json:"vote_count"`
+	VoteMetrics
 	*MovieAlternativeTitlesAppend
 	*MovieChangesAppend
 	*MovieCreditsAppend
@@ -366,9 +365,8 @@ type MovieImage struct {
 	FilePath    string  `json:"file_path"`
 	Height      int     `json:"height"`
 	Iso639_1    string  `json:"iso_639_1"`
-	VoteAverage float32 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // MovieImages type is a struct for images JSON response.

--- a/networks.go
+++ b/networks.go
@@ -68,9 +68,8 @@ type NetworkImage struct {
 	Height      int     `json:"height"`
 	ID          string  `json:"id"`
 	FileType    string  `json:"file_type"`
-	VoteAverage float64 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // NetworkImages type is a struct for images JSON response.

--- a/people.go
+++ b/people.go
@@ -153,7 +153,6 @@ type PersonMovieCredits struct {
 		ID               int64   `json:"id"`
 		Order            int     `json:"order"`
 		Video            bool    `json:"video"`
-		VoteCount        int64   `json:"vote_count"`
 		Adult            bool    `json:"adult"`
 		BackdropPath     string  `json:"backdrop_path"`
 		GenreIDs         []int64 `json:"genre_ids"`
@@ -161,9 +160,9 @@ type PersonMovieCredits struct {
 		OriginalTitle    string  `json:"original_title"`
 		Popularity       float32 `json:"popularity"`
 		Title            string  `json:"title"`
-		VoteAverage      float32 `json:"vote_average"`
 		Overview         string  `json:"overview"`
 		ReleaseDate      string  `json:"release_date"`
+		VoteMetrics
 	} `json:"cast"`
 	Crew []struct {
 		ID               int64   `json:"id"`
@@ -172,10 +171,8 @@ type PersonMovieCredits struct {
 		OriginalTitle    string  `json:"original_title"`
 		Job              string  `json:"job"`
 		Overview         string  `json:"overview"`
-		VoteCount        int64   `json:"vote_count"`
 		Video            bool    `json:"video"`
 		ReleaseDate      string  `json:"release_date"`
-		VoteAverage      float32 `json:"vote_average"`
 		Title            string  `json:"title"`
 		Popularity       float32 `json:"popularity"`
 		GenreIDs         []int64 `json:"genre_ids"`
@@ -183,6 +180,7 @@ type PersonMovieCredits struct {
 		Adult            bool    `json:"adult"`
 		PosterPath       string  `json:"poster_path"`
 		CreditID         string  `json:"credit_id"`
+		VoteMetrics
 	} `json:"crew"`
 	ID int64 `json:"id,omitempty"`
 }
@@ -220,8 +218,6 @@ type PersonTVCredits struct {
 		Character        string   `json:"character"`
 		Name             string   `json:"name"`
 		PosterPath       string   `json:"poster_path"`
-		VoteCount        int64    `json:"vote_count"`
-		VoteAverage      float32  `json:"vote_average"`
 		Popularity       float32  `json:"popularity"`
 		EpisodeCount     int      `json:"episode_count"`
 		OriginalLanguage string   `json:"original_language"`
@@ -229,6 +225,7 @@ type PersonTVCredits struct {
 		BackdropPath     string   `json:"backdrop_path"`
 		Overview         string   `json:"overview"`
 		OriginCountry    []string `json:"origin_country"`
+		VoteMetrics
 	} `json:"cast"`
 	Crew []struct {
 		ID               int64    `json:"id"`
@@ -244,10 +241,9 @@ type PersonTVCredits struct {
 		FirstAirDate     string   `json:"first_air_date"`
 		BackdropPath     string   `json:"backdrop_path"`
 		Popularity       float32  `json:"popularity"`
-		VoteCount        int64    `json:"vote_count"`
-		VoteAverage      float32  `json:"vote_average"`
 		PosterPath       string   `json:"poster_path"`
 		CreditID         string   `json:"credit_id"`
+		VoteMetrics
 	} `json:"crew"`
 	ID int64 `json:"id,omitempty"`
 }
@@ -282,11 +278,9 @@ type PersonCombinedCredits struct {
 		Character        string   `json:"character"`
 		OriginalTitle    string   `json:"original_title"`
 		Overview         string   `json:"overview"`
-		VoteCount        int64    `json:"vote_count"`
 		Video            bool     `json:"video"`
 		MediaType        string   `json:"media_type"`
 		ReleaseDate      string   `json:"release_date"`
-		VoteAverage      float32  `json:"vote_average"`
 		Title            string   `json:"title"`
 		Popularity       float32  `json:"popularity"`
 		OriginalLanguage string   `json:"original_language"`
@@ -300,6 +294,7 @@ type PersonCombinedCredits struct {
 		OriginalName     string   `json:"original_name"`
 		Name             string   `json:"name"`
 		FirstAirDate     string   `json:"first_air_date"`
+		VoteMetrics
 	} `json:"cast"`
 	Crew []struct {
 		ID               int64   `json:"id"`
@@ -308,7 +303,6 @@ type PersonCombinedCredits struct {
 		OriginalTitle    string  `json:"original_title"`
 		Job              string  `json:"job"`
 		Overview         string  `json:"overview"`
-		VoteCount        int64   `json:"vote_count"`
 		Video            bool    `json:"video"`
 		MediaType        string  `json:"media_type"`
 		PosterPath       string  `json:"poster_path"`
@@ -316,10 +310,10 @@ type PersonCombinedCredits struct {
 		Title            string  `json:"title"`
 		Popularity       float32 `json:"popularity"`
 		GenreIDs         []int64 `json:"genre_ids"`
-		VoteAverage      float32 `json:"vote_average"`
 		Adult            bool    `json:"adult"`
 		ReleaseDate      string  `json:"release_date"`
 		CreditID         string  `json:"credit_id"`
+		VoteMetrics
 	} `json:"crew"`
 	ID int64 `json:"id,omitempty"`
 }
@@ -391,10 +385,9 @@ type PersonImage struct {
 	Iso639_1    string  `json:"iso_639_1"`
 	Width       int     `json:"width"`
 	Height      int     `json:"height"`
-	VoteCount   int64   `json:"vote_count"`
-	VoteAverage float32 `json:"vote_average"`
 	FilePath    string  `json:"file_path"`
 	AspectRatio float32 `json:"aspect_ratio"`
+	VoteMetrics
 }
 
 // PersonImages type is a struct for images JSON response.
@@ -429,13 +422,11 @@ type PersonTaggedImages struct {
 	PaginatedResultsMeta
 	Results []struct {
 		Iso639_1    string  `json:"iso_639_1"`
-		VoteCount   int64   `json:"vote_count"`
 		MediaType   string  `json:"media_type"`
 		FilePath    string  `json:"file_path"`
 		AspectRatio float32 `json:"aspect_ratio"`
 		Media       struct {
 			Popularity       float32 `json:"popularity"`
-			VoteCount        int64   `json:"vote_count"`
 			Video            bool    `json:"video"`
 			PosterPath       string  `json:"poster_path"`
 			ID               int64   `json:"id"`
@@ -445,13 +436,13 @@ type PersonTaggedImages struct {
 			OriginalTitle    string  `json:"original_title"`
 			GenreIDs         []int64 `json:"genre_ids"`
 			Title            string  `json:"title"`
-			VoteAverage      float32 `json:"vote_average"`
 			Overview         string  `json:"overview"`
 			ReleaseDate      string  `json:"release_date"`
+			VoteMetrics
 		} `json:"media"`
-		Height      int     `json:"height"`
-		VoteAverage float32 `json:"vote_average"`
-		Width       int     `json:"width"`
+		Height int `json:"height"`
+		Width  int `json:"width"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -561,8 +552,6 @@ type PersonPopular struct {
 			MediaType        string   `json:"media_type"`
 			Name             string   `json:"name,omitempty"`
 			Title            string   `json:"title,omitempty"`
-			VoteCount        int64    `json:"vote_count"`
-			VoteAverage      float32  `json:"vote_average"`
 			PosterPath       string   `json:"poster_path"`
 			FirstAirDate     string   `json:"first_air_date,omitempty"`
 			ReleaseDate      string   `json:"release_date,omitempty"`
@@ -572,6 +561,7 @@ type PersonPopular struct {
 			BackdropPath     string   `json:"backdrop_path"`
 			Overview         string   `json:"overview"`
 			OriginCountry    []string `json:"origin_country,omitempty"`
+			VoteMetrics
 		} `json:"known_for"`
 		Adult bool `json:"adult"`
 	} `json:"results"`

--- a/results.go
+++ b/results.go
@@ -28,11 +28,10 @@ type MovieResult struct {
 	PosterPath       string  `json:"poster_path"`
 	BackdropPath     string  `json:"backdrop_path"`
 	Popularity       float32 `json:"popularity"`
-	VoteCount        int64   `json:"vote_count"`
-	VoteAverage      float32 `json:"vote_average"`
 	GenreIDs         []int64 `json:"genre_ids"`
 	Adult            bool    `json:"adult"`
 	Video            bool    `json:"video"`
+	VoteMetrics
 }
 
 // AccountFavoriteMoviesResults Result Types
@@ -50,8 +49,7 @@ type AccountFavoriteMoviesResults struct {
 		Popularity       float64 `json:"popularity"`
 		Title            string  `json:"title"`
 		Video            bool    `json:"video"`
-		VoteAverage      float64 `json:"vote_average"`
-		VoteCount        int64   `json:"vote_count"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -69,10 +67,9 @@ type TVShowResult struct {
 	PosterPath       string   `json:"poster_path"`
 	BackdropPath     string   `json:"backdrop_path"`
 	Popularity       float32  `json:"popularity"`
-	VoteCount        int64    `json:"vote_count"`
-	VoteAverage      float32  `json:"vote_average"`
 	GenreIDs         []int64  `json:"genre_ids"`
 	OriginCountry    []string `json:"origin_country"`
+	VoteMetrics
 }
 
 // AccountFavoriteTVShowsResults Result Types
@@ -89,8 +86,7 @@ type AccountFavoriteTVShowsResults struct {
 		PosterPath       string   `json:"poster_path"`
 		Popularity       float64  `json:"popularity"`
 		Name             string   `json:"name"`
-		VoteAverage      float64  `json:"vote_average"`
-		VoteCount        int64    `json:"vote_count"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -106,9 +102,8 @@ type AccountRatedTVEpisodesResults struct {
 		SeasonNumber   int     `json:"season_number"`
 		ShowID         int64   `json:"show_id"`
 		StillPath      string  `json:"still_path"`
-		VoteAverage    float64 `json:"vote_average"`
-		VoteCount      int64   `json:"vote_count"`
 		Rating         float32 `json:"rating"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -183,13 +178,11 @@ type SearchMultiResults struct {
 		ID               int64    `json:"id"`
 		Overview         string   `json:"overview,omitempty"`
 		BackdropPath     string   `json:"backdrop_path,omitempty"`
-		VoteAverage      float32  `json:"vote_average,omitempty"`
 		MediaType        string   `json:"media_type"`
 		FirstAirDate     string   `json:"first_air_date,omitempty"`
 		OriginCountry    []string `json:"origin_country,omitempty"`
 		GenreIDs         []int64  `json:"genre_ids,omitempty"`
 		OriginalLanguage string   `json:"original_language,omitempty"`
-		VoteCount        int64    `json:"vote_count,omitempty"`
 		Name             string   `json:"name,omitempty"`
 		OriginalName     string   `json:"original_name,omitempty"`
 		Adult            bool     `json:"adult,omitempty"`
@@ -211,10 +204,10 @@ type SearchMultiResults struct {
 			Title            string  `json:"title"`
 			BackdropPath     string  `json:"backdrop_path"`
 			Popularity       float32 `json:"popularity"`
-			VoteCount        int64   `json:"vote_count"`
 			Video            bool    `json:"video"`
-			VoteAverage      float32 `json:"vote_average"`
+			VoteMetrics
 		} `json:"known_for,omitempty"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -242,8 +235,7 @@ type SearchPeopleResults struct {
 			ReleaseDate      string   `json:"release_date,omitempty"` // Movie
 			Title            string   `json:"title,omitempty"`        // Movie
 			Video            bool     `json:"video,omitempty"`        // Movie
-			VoteAverage      float32  `json:"vote_average"`
-			VoteCount        int64    `json:"vote_count"`
+			VoteMetrics
 		} `json:"known_for"`
 		KnownForDepartment string  `json:"known_for_department"`
 		Name               string  `json:"name"`
@@ -272,8 +264,6 @@ type TrendingResults struct {
 		ReleaseDate        string   `json:"release_date,omitempty"`
 		Title              string   `json:"title,omitempty"`
 		Video              bool     `json:"video,omitempty"`
-		VoteAverage        float32  `json:"vote_average,omitempty"`
-		VoteCount          int64    `json:"vote_count,omitempty"`
 		Popularity         float32  `json:"popularity,omitempty"`
 		FirstAirDate       string   `json:"first_air_date,omitempty"`
 		Name               string   `json:"name,omitempty"`
@@ -294,11 +284,11 @@ type TrendingResults struct {
 			ReleaseDate      string  `json:"release_date"`
 			Title            string  `json:"title"`
 			Video            bool    `json:"video"`
-			VoteAverage      float64 `json:"vote_average"`
-			VoteCount        int     `json:"vote_count"`
 			Popularity       float64 `json:"popularity"`
 			MediaType        string  `json:"media_type"`
+			VoteMetrics
 		} `json:"known_for,omitempty"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -371,9 +361,8 @@ type MovieRecommendationsResults struct {
 		Title            string  `json:"title"`
 		BackdropPath     string  `json:"backdrop_path"`
 		Popularity       float32 `json:"popularity"`
-		VoteCount        int64   `json:"vote_count"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -415,9 +404,8 @@ type MovieNowPlayingResults struct {
 		Title            string  `json:"title"`
 		BackdropPath     string  `json:"backdrop_path"`
 		Popularity       float32 `json:"popularity"`
-		VoteCount        int64   `json:"vote_count"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -435,9 +423,8 @@ type MoviePopularResults struct {
 		Title            string  `json:"title"`
 		BackdropPath     string  `json:"backdrop_path"`
 		Popularity       float32 `json:"popularity"`
-		VoteCount        int64   `json:"vote_count"`
 		Video            bool    `json:"video"`
-		VoteAverage      float32 `json:"vote_average"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -491,15 +478,14 @@ type TVRecommendationsResults struct {
 		Popularity       float32  `json:"popularity"`
 		ID               int64    `json:"id"`
 		BackdropPath     string   `json:"backdrop_path"`
-		VoteAverage      float32  `json:"vote_average"`
 		Overview         string   `json:"overview"`
 		FirstAirDate     string   `json:"first_air_date"`
 		OriginCountry    []string `json:"origin_country"`
 		GenreIDs         []int64  `json:"genre_ids"`
 		OriginalLanguage string   `json:"original_language"`
-		VoteCount        int64    `json:"vote_count"`
 		Name             string   `json:"name"`
 		OriginalName     string   `json:"original_name"`
+		VoteMetrics
 	} `json:"results"`
 }
 
@@ -569,13 +555,12 @@ type TVAiringTodayResults struct {
 		Name             string   `json:"name"`
 		Popularity       float32  `json:"popularity"`
 		OriginCountry    []string `json:"origin_country"`
-		VoteCount        int64    `json:"vote_count"`
 		FirstAirDate     string   `json:"first_air_date"`
 		BackdropPath     string   `json:"backdrop_path"`
 		OriginalLanguage string   `json:"original_language"`
 		ID               int64    `json:"id"`
-		VoteAverage      float32  `json:"vote_average"`
 		Overview         string   `json:"overview"`
 		PosterPath       string   `json:"poster_path"`
+		VoteMetrics
 	} `json:"results"`
 }

--- a/tv.go
+++ b/tv.go
@@ -37,8 +37,7 @@ type TVDetails struct {
 	Status              string              `json:"status"`
 	Tagline             string              `json:"tagline"`
 	Type                string              `json:"type"`
-	VoteAverage         float32             `json:"vote_average"`
-	VoteCount           int64               `json:"vote_count"`
+	VoteMetrics
 	*TVAggregateCreditsAppend
 	*TVAlternativeTitlesAppend
 	*TVChangesAppend
@@ -520,9 +519,8 @@ type TVImage struct {
 	FilePath    string  `json:"file_path"`
 	Height      int     `json:"height"`
 	Iso639_1    string  `json:"iso_639_1"`
-	VoteAverage float32 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // TVImages type is a struct for images JSON response.

--- a/tv_episode_groups.go
+++ b/tv_episode_groups.go
@@ -25,9 +25,8 @@ type TVEpisodeGroupsDetails struct {
 			SeasonNumber   int             `json:"season_number"`
 			ShowID         int64           `json:"show_id"`
 			StillPath      string          `json:"still_path"`
-			VoteAverage    float32         `json:"vote_average"`
-			VoteCount      int64           `json:"vote_count"`
 			Order          int             `json:"order"`
+			VoteMetrics
 		} `json:"episodes"`
 		Locked bool `json:"locked"`
 	} `json:"groups"`

--- a/tv_episodes.go
+++ b/tv_episodes.go
@@ -28,15 +28,14 @@ type TVEpisodeDetails struct {
 		Gender      int    `json:"gender"`
 		ProfilePath string `json:"profile_path"`
 	} `json:"guest_stars"`
-	Name           string  `json:"name"`
-	Overview       string  `json:"overview"`
-	ID             int64   `json:"id"`
-	ProductionCode string  `json:"production_code"`
-	Runtime        int     `json:"runtime"`
-	SeasonNumber   int     `json:"season_number"`
-	StillPath      string  `json:"still_path"`
-	VoteAverage    float32 `json:"vote_average"`
-	VoteCount      int64   `json:"vote_count"`
+	Name           string `json:"name"`
+	Overview       string `json:"overview"`
+	ID             int64  `json:"id"`
+	ProductionCode string `json:"production_code"`
+	Runtime        int    `json:"runtime"`
+	SeasonNumber   int    `json:"season_number"`
+	StillPath      string `json:"still_path"`
+	VoteMetrics
 	*TVEpisodeCreditsAppend
 	*TVEpisodeExternalIDsAppend
 	*TVEpisodeImagesAppend
@@ -258,9 +257,8 @@ type TVEpisodeImage struct {
 	FilePath    string  `json:"file_path"`
 	Height      int     `json:"height"`
 	Iso6391     any     `json:"iso_639_1"`
-	VoteAverage float32 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // TVEpisodeImages type is a struct for images JSON response.

--- a/tv_seasons.go
+++ b/tv_seasons.go
@@ -7,19 +7,18 @@ type TVSeasonDetails struct {
 	IDString string `json:"_id"`
 	AirDate  string `json:"air_date"`
 	Episodes []struct {
-		AirDate        string  `json:"air_date"`
-		EpisodeNumber  int     `json:"episode_number"`
-		ID             int64   `json:"id"`
-		Name           string  `json:"name"`
-		Overview       string  `json:"overview"`
-		ProductionCode string  `json:"production_code"`
-		Runtime        int     `json:"runtime"`
-		SeasonNumber   int     `json:"season_number"`
-		ShowID         int64   `json:"show_id"`
-		StillPath      string  `json:"still_path"`
-		VoteAverage    float32 `json:"vote_average"`
-		VoteCount      int64   `json:"vote_count"`
-		Crew           []struct {
+		AirDate        string `json:"air_date"`
+		EpisodeNumber  int    `json:"episode_number"`
+		ID             int64  `json:"id"`
+		Name           string `json:"name"`
+		Overview       string `json:"overview"`
+		ProductionCode string `json:"production_code"`
+		Runtime        int    `json:"runtime"`
+		SeasonNumber   int    `json:"season_number"`
+		ShowID         int64  `json:"show_id"`
+		StillPath      string `json:"still_path"`
+		VoteMetrics
+		Crew []struct {
 			ID          int64  `json:"id"`
 			CreditID    string `json:"credit_id"`
 			Name        string `json:"name"`
@@ -258,9 +257,8 @@ type TVSeasonImage struct {
 	FilePath    string  `json:"file_path"`
 	Height      int     `json:"height"`
 	Iso639_1    string  `json:"iso_639_1"`
-	VoteAverage float32 `json:"vote_average"`
-	VoteCount   int64   `json:"vote_count"`
 	Width       int     `json:"width"`
+	VoteMetrics
 }
 
 // TVSeasonImages type is a struct for images JSON response.

--- a/types.go
+++ b/types.go
@@ -84,34 +84,32 @@ type Season struct {
 // It includes information such as air date, episode and season numbers, production code,
 // episode overview, voting statistics, and related media paths.
 type LastEpisodeToAir struct {
-	AirDate        string  `json:"air_date"`
-	EpisodeNumber  int     `json:"episode_number"`
-	ID             int64   `json:"id"`
-	Name           string  `json:"name"`
-	Overview       string  `json:"overview"`
-	ProductionCode string  `json:"production_code"`
-	SeasonNumber   int     `json:"season_number"`
-	ShowID         int64   `json:"show_id"`
-	StillPath      string  `json:"still_path"`
-	VoteAverage    float32 `json:"vote_average"`
-	VoteCount      int64   `json:"vote_count"`
+	AirDate        string `json:"air_date"`
+	EpisodeNumber  int    `json:"episode_number"`
+	ID             int64  `json:"id"`
+	Name           string `json:"name"`
+	Overview       string `json:"overview"`
+	ProductionCode string `json:"production_code"`
+	SeasonNumber   int    `json:"season_number"`
+	ShowID         int64  `json:"show_id"`
+	StillPath      string `json:"still_path"`
+	VoteMetrics
 }
 
 // NextEpisodeToAir represents the details of the next episode scheduled to air for a TV show.
 // It includes information such as air date, episode and season numbers, show and episode IDs,
 // episode name and overview, production code, still image path, and voting statistics.
 type NextEpisodeToAir struct {
-	AirDate        string  `json:"air_date"`
-	EpisodeNumber  int     `json:"episode_number"`
-	ID             int64   `json:"id"`
-	Name           string  `json:"name"`
-	Overview       string  `json:"overview"`
-	ProductionCode string  `json:"production_code"`
-	SeasonNumber   int     `json:"season_number"`
-	ShowID         int64   `json:"show_id"`
-	StillPath      string  `json:"still_path"`
-	VoteAverage    float32 `json:"vote_average"`
-	VoteCount      int64   `json:"vote_count"`
+	AirDate        string `json:"air_date"`
+	EpisodeNumber  int    `json:"episode_number"`
+	ID             int64  `json:"id"`
+	Name           string `json:"name"`
+	Overview       string `json:"overview"`
+	ProductionCode string `json:"production_code"`
+	SeasonNumber   int    `json:"season_number"`
+	ShowID         int64  `json:"show_id"`
+	StillPath      string `json:"still_path"`
+	VoteMetrics
 }
 
 // Network represents a television network with its identifying information,
@@ -131,4 +129,9 @@ type CreatedBy struct {
 	Name        string `json:"name"`
 	Gender      int    `json:"gender"`
 	ProfilePath string `json:"profile_path"`
+}
+
+type VoteMetrics struct {
+	VoteCount   int64   `json:"vote_count"`
+	VoteAverage float32 `json:"vote_average"`
 }


### PR DESCRIPTION
# Description

Refactored vote_average and vote_count fields by moving them into a dedicated VoteMetrics struct. Updated all related structures accordingly.

These two fields are always used together in TMDB responses. Grouping them into a common VoteMetrics struct provides better consistency, improves structure clarity, and avoids duplication.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No test needed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
