### PR TITLE
Add MediaType field for collection parts

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -14,6 +14,7 @@ type CollectionDetails struct {
 		BackdropPath     string  `json:"backdrop_path"`
 		GenreIDs         []int64 `json:"genre_ids"`
 		ID               int64   `json:"id"`
+		MediaType        string  `json:"media_type"`
 		OriginalLanguage string  `json:"original_language"`
 		OriginalTitle    string  `json:"original_title"`
 		Overview         string  `json:"overview"`


### PR DESCRIPTION
Collections can (apparently!) contain other collections, and there's not a good way to tell them apart from movies at the minute.