### PR TITLE
fix: remove deprecated person tagged images endpoint

### DIFF
--- a/people.go
+++ b/people.go
@@ -24,7 +24,6 @@ type PersonDetails struct {
 	*PersonCombinedCreditsAppend
 	*PersonExternalIDsAppend
 	*PersonImagesAppend
-	*PersonTaggedImagesAppend
 	*PersonTranslationsAppend
 }
 
@@ -62,12 +61,6 @@ type PersonExternalIDsAppend struct {
 // for images in append to response.
 type PersonImagesAppend struct {
 	Images *PersonImages `json:"images,omitempty"`
-}
-
-// PersonTaggedImagesAppend type is a struct
-// for tagged images in append to response.
-type PersonTaggedImagesAppend struct {
-	TaggedImages *PersonTaggedImages `json:"tagged_images,omitempty"`
 }
 
 // PersonTranslationsAppend type is a struct
@@ -410,55 +403,6 @@ func (c *Client) GetPersonImages(
 		return nil, err
 	}
 	return &personImages, nil
-}
-
-// PersonTaggedImages type is a struct for tagged images JSON response.
-type PersonTaggedImages struct {
-	ID int64 `json:"id"`
-	PaginatedResultsMeta
-	Results []struct {
-		ImageBase
-		Iso639_1  string `json:"iso_639_1"`
-		MediaType string `json:"media_type"`
-		Media     struct {
-			Popularity       float32 `json:"popularity"`
-			Video            bool    `json:"video"`
-			PosterPath       string  `json:"poster_path"`
-			ID               int64   `json:"id"`
-			Adult            bool    `json:"adult"`
-			BackdropPath     string  `json:"backdrop_path"`
-			OriginalLanguage string  `json:"original_language"`
-			OriginalTitle    string  `json:"original_title"`
-			GenreIDs         []int64 `json:"genre_ids"`
-			Title            string  `json:"title"`
-			Overview         string  `json:"overview"`
-			ReleaseDate      string  `json:"release_date"`
-			VoteMetrics
-		} `json:"media"`
-	} `json:"results"`
-}
-
-// GetPersonTaggedImages get the images that this person has been tagged in.
-//
-// https://developers.themoviedb.org/3/people/get-tagged-images
-func (c *Client) GetPersonTaggedImages(
-	id int,
-	urlOptions map[string]string,
-) (*PersonTaggedImages, error) {
-	options := c.fmtOptions(urlOptions)
-	tmdbURL := fmt.Sprintf(
-		"%s%s%d/tagged_images?api_key=%s%s",
-		baseURL,
-		personURL,
-		id,
-		c.apiKey,
-		options,
-	)
-	personTaggedImages := PersonTaggedImages{}
-	if err := c.get(tmdbURL, &personTaggedImages); err != nil {
-		return nil, err
-	}
-	return &personTaggedImages, nil
 }
 
 // PersonTranslations type is a struct for translations JSON response.

--- a/people_test.go
+++ b/people_test.go
@@ -147,26 +147,6 @@ func (suite *TMBDTestSuite) TestGetPersonImagesFail() {
 	suite.NotNil(err)
 }
 
-func (suite *TMBDTestSuite) TestGetPersonTaggedImages() {
-	tomCruise, err := suite.client.GetPersonTaggedImages(tomCruiseID, nil)
-	suite.Nil(err)
-	suite.NotNil(tomCruise.ID)
-}
-
-func (suite *TMBDTestSuite) TestGetPersonTaggedImagesFail() {
-	suite.client.apiKey = ""
-	_, err := suite.client.GetPersonTaggedImages(0, nil)
-	suite.NotNil(err)
-}
-
-func (suite *TMBDTestSuite) TestGetPersonTaggedImagesWithOptions() {
-	options := make(map[string]string)
-	options["language"] = "en-US"
-	tomCruise, err := suite.client.GetPersonTaggedImages(tomCruiseID, options)
-	suite.Nil(err)
-	suite.NotNil(tomCruise.ID)
-}
-
 func (suite *TMBDTestSuite) TestGetPersonTranslations() {
 	tomCruise, err := suite.client.GetPersonTranslations(tomCruiseID, nil)
 	suite.Nil(err)

--- a/tv_seasons_test.go
+++ b/tv_seasons_test.go
@@ -17,7 +17,7 @@ func (suite *TMBDTestSuite) TestGetTVSeasonDetailsWithOptions() {
 	options["language"] = "pt-BR"
 	got, err := suite.client.GetTVSeasonDetails(gotID, 1, options)
 	suite.Nil(err)
-	suite.Equal("1ª Temporada", got.Name)
+	suite.Equal("Temporada 1", got.Name)
 }
 
 func (suite *TMBDTestSuite) TestGetTVSeasonChange() {


### PR DESCRIPTION
# Description

- Remove `PersonTaggedImages` and `PersonTaggedImagesAppend` structs
- Remove deprecated `GetPersonTaggedImages` function
- Remove associated test cases:
  - TestGetPersonTaggedImages
  - TestGetPersonTaggedImagesFail
  - TestGetPersonTaggedImagesWithOptions
- Fix TestGetTVSeasonDetailsWithOptions test

The `/person/{id}/tagged_images` endpoint has been deprecated by TMDB and is no longer functional. This change removes all related code to maintain a clean and functional codebase.

BREAKING CHANGE: The `GetPersonTaggedImages` function and related types have been removed as the underlying TMDB API endpoint is no longer available. Users should use alternative endpoints for similar functionality.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
